### PR TITLE
Simplify dependency setup of magpdf on structure.

### DIFF
--- a/example_jointRefinement.py
+++ b/example_jointRefinement.py
@@ -77,10 +77,9 @@ totpdf.setProfile(profile)
 totpdf.setEquation("nucscale * nucpdf + magpdf(parascale, ordscale)")
 
 # Make magnetic PDF depend on any changes to the atomic structure.
-# Cover your eyes, but a structure change will now behave as ordscale
-# modification and will forget cached values of magpdf.
-for o in totpdf.ordscale._observers:
-    nucpdf.phase.addObserver(o)
+# Cover your eyes, but a structure change will now trigger the same
+# reevaluations as if ordscale were modified.
+nucpdf.phase.addObserver(totpdf.ordscale.notify)
 
 # The FitRecipe does the work of calculating the PDF with the fit variable
 # that we give it.


### PR DESCRIPTION
Here is a nicer setup that ensures magpdf re-evaluations with structure change.
I also found why was magpdf calculated every time.  There was a round-off error in diffpy.Structure, which caused a tiny difference between the assigned and stored ADP-s.
The structure then always appeared different from what was set by srfit.

This issue was fixed in diffpy/diffpy.Structure@742af86f7ac4befef0878303f631d352ef298bf1 - please update your diffpy.Structure to take advantage of that.  The run-time of example_jointRefinement.py improved from 14 --> 10s.